### PR TITLE
referenceIds header explode

### DIFF
--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -230,7 +230,8 @@ class MailboxService
                     // Search Criteria 3: Find ticket based on reference id
                     // Break references into ind. message id collection, and iteratively 
                     // search for existing threads for these message ids.
-                    $referenceIds = explode(' ', $criteriaValue);
+                    $separator = (str_contains($criteriaValue, ',')) ? ',' : ' ';
+                    $referenceIds = explode($separator, $criteriaValue);
 
                     foreach ($referenceIds as $messageId) {
                         $thread = $threadRepository->findOneByMessageId($messageId);


### PR DESCRIPTION
Some mail clients (ie OWA) use commas instead newline for multiple ids in "reference" header.

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
reference header is not correctly parsed when mail is sent from some clients (ie OWA). Some clients in fact use commas instead newline for separating multiple ids.

### 2. What does this change do, exactly?
The code looks if there is any comma in the reference header. If any, it use comma in the function "explode". There is non possibility that a message id contains commas, so if there is one comma it must be the separator. If comma is not found, the space is used as separator.


### 3. Please link to the relevant issues (if any).
