### PR TITLE
Create a option for user to delete mail from inbox after creation of ticket successfully

### DIFF
--- a/Controller/MailboxChannel.php
+++ b/Controller/MailboxChannel.php
@@ -73,6 +73,7 @@ class MailboxChannel extends AbstractController
                 ($mailbox = new Mailbox(!empty($params['id']) ? $params['id'] : null))
                     ->setName($params['name'])
                     ->setIsEnabled(!empty($params['isEnabled']) && 'on' == $params['isEnabled'] ? true : false)
+                    ->setIsDeleted(!empty($params['isDeleted']) && 'on' == $params['isDeleted'] ? true : false)
                     ->setImapConfiguration($imapConfiguration)
                     ->setSwiftMailerConfiguration($swiftmailerConfiguration);
 
@@ -117,7 +118,7 @@ class MailboxChannel extends AbstractController
             if (!empty($params['imap']['transport'])) {
                 ($imapConfiguration = ImapConfiguration::createTransportDefinition($params['imap']['transport'], !empty($params['imap']['host']) ? trim($params['imap']['host'], '"') : null))
                     ->setUsername($params['imap']['username'])
-                    ->setPassword($params['imap']['password']);
+                    ->setPassword(base64_encode($params['imap']['password']));
             }
 
             // Swiftmailer Configuration
@@ -145,6 +146,7 @@ class MailboxChannel extends AbstractController
                         $mailbox
                             ->setName($params['name'])
                             ->setIsEnabled(!empty($params['isEnabled']) && 'on' == $params['isEnabled'] ? true : false)
+                            ->setIsDeleted(!empty($params['isDeleted']) && 'on' == $params['isDeleted'] ? true : false)
                             ->setImapConfiguration($imapConfiguration)
                             ->setSwiftMailerConfiguration($swiftmailerConfiguration);
 

--- a/Controller/MailboxChannel.php
+++ b/Controller/MailboxChannel.php
@@ -53,7 +53,7 @@ class MailboxChannel extends AbstractController
             if (!empty($params['imap']['transport'])) {
                 ($imapConfiguration = ImapConfiguration::createTransportDefinition($params['imap']['transport'], !empty($params['imap']['host']) ? trim($params['imap']['host'], '"') : null))
                     ->setUsername($params['imap']['username'])
-                    ->setPassword($params['imap']['password']);
+                    ->setPassword(base64_encode($params['imap']['password']));
             }
 
             // Swiftmailer Configuration

--- a/Controller/MailboxChannelXHR.php
+++ b/Controller/MailboxChannelXHR.php
@@ -41,6 +41,7 @@ class MailboxChannelXHR extends AbstractController
                 'id' => $mailbox->getId(),
                 'name' => $mailbox->getName(),
                 'isEnabled' => $mailbox->getIsEnabled(),
+                'isDeleted' => $mailbox->getIsDeleted(),
             ];
         }, $this->mailboxService->parseMailboxConfigurations()->getMailboxes());
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->node('name', 'scalar')->cannotBeEmpty()->end()
                             ->node('enabled', 'boolean')->defaultFalse()->end()
+                            ->node('deleted', 'boolean')->defaultFalse()->end()
                             ->node('smtp_server', 'array')
                                 ->children()
                                     ->node('mailer_id', 'scalar')->defaultValue('default')->end()

--- a/Resources/views/manageConfigurations.html.twig
+++ b/Resources/views/manageConfigurations.html.twig
@@ -85,6 +85,22 @@
 					</label>
 				</div>
 
+				<div class="uv-element-block">
+					<label>
+						<div class="uv-checkbox">
+							{% if mailbox.isDeleted is defined and mailbox.isDeleted == true %}
+								<input name="isDeleted" type="checkbox" checked="">
+							{% else %}
+								<input name="isDeleted" type="checkbox">
+							{% endif %}
+
+							<span class="uv-checkbox-view"></span>
+						</div>
+
+						<span class="uv-checkbox-label">{{ 'Delete from Inbox'|trans }}</span>
+					</label>
+				</div>
+
 				<div class="uv-hr"></div>
 
 				{# IMAP Settings #}

--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -86,6 +86,7 @@ class MailboxService
             ($mailbox = new Mailbox($id))
                 ->setName($params['name'])
                 ->setIsEnabled($params['enabled'])
+                ->setIsDeleted($params['deleted'])
                 ->setImapConfiguration($imapConfiguration);
             
             if (!empty($swiftmailerConfiguration)) {

--- a/Templates/PackageConfigurations/Mailbox.php
+++ b/Templates/PackageConfigurations/Mailbox.php
@@ -4,6 +4,7 @@ return <<<TEMPLATE
         [[ id ]]:
             name: [[ name ]]
             enabled: [[ status ]]
+            deleted: [[ delete_status ]]
 
             # [SMTP] Outgoing mail server
             # Swiftmailer smtp mailer to use for sending emails through on behalf of this mailbox

--- a/Utils/Mailbox/Mailbox.php
+++ b/Utils/Mailbox/Mailbox.php
@@ -14,6 +14,7 @@ class Mailbox
     private $id = null;
     private $name = null;
     private $isEnabled = false;
+    private $isDeleted = false;
     private $imapConfiguration = null;
     private $swiftmailerConfiguration = null;
 
@@ -56,6 +57,19 @@ class Mailbox
         return $this->isEnabled;
     }
 
+    public function getIsDeleted() : bool
+    {
+        return $this->isDeleted;
+    }
+
+    public function setIsDeleted(bool $isDeleted)
+    {
+        $this->isDeleted = $isDeleted;
+
+        return $this;
+    }
+
+
     public function setImapConfiguration(ImapConfiguration $imapConfiguration)
     {
         $this->imapConfiguration = $imapConfiguration;
@@ -94,6 +108,7 @@ class Mailbox
             '[[ id ]]' => $this->getId(),
             '[[ name ]]' => $this->getName(),
             '[[ status ]]' => $this->getIsEnabled() ? 'true' : 'false',
+            '[[ delete_status ]]' => $this->getIsDeleted() ? 'true' : 'false',
             '[[ swiftmailer_id ]]' => $swiftmailerConfiguration ? $swiftmailerConfiguration->getId() : '~',
             '[[ imap_host ]]' => $imapConfiguration->getHost(),
             '[[ imap_username ]]' => $imapConfiguration->getUsername(),


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Now, After running the refresh: mailbox command the mail does not delete from the inbox.

### 2. What does this change do, exactly?
As mail does not delete from the inbox, it will take more time to refresh the mailbox on every hit of the command.
As we provide an option to delete mail from the inbox after the creation of the ticket. If someone wants to use this feature they have an option to delete mail from inbox in the mailbox setup section. After checked the mark, it will delete the mail from the inbox 
on every run of the refresh command
### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/433