### PR TITLE
changes for email comparsion in mailboxService

### DIFF
--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -161,7 +161,7 @@ class MailboxService
     public function getMailboxByEmail($email)
     {
         foreach ($this->getRegisteredMailboxes() as $registeredMailbox) {
-            if ($email === $registeredMailbox['imap_server']['username']) {
+            if (strtolower($email) === strtolower($registeredMailbox['imap_server']['username'])) {
                 return $registeredMailbox;
             }
         }
@@ -172,7 +172,7 @@ class MailboxService
     public function getMailboxByToEmail($email)
     {
         foreach ($this->getRegisteredMailboxes() as $registeredMailbox) {
-            if ($email === $registeredMailbox['imap_server']['username']) {
+            if (strtolower($email) === strtolower($registeredMailbox['imap_server']['username'])) {
                 return true;
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a user saves a mailbox with test@test.com & it run the refresh command with Test@test.com then it will show mailbox not found

### 2. What does this change do, exactly?
It compare the email address in their lower version so that it will easy to compare 

### 3. Please link to the relevant issues (if any).
https://forums.uvdesk.com/topic/1829/problem-in-the-php-mailbox/2