### PR TITLE
changes for fetching old mailbox without deleted option

### DIFF
--- a/Controller/MailboxChannelXHR.php
+++ b/Controller/MailboxChannelXHR.php
@@ -41,7 +41,7 @@ class MailboxChannelXHR extends AbstractController
                 'id' => $mailbox->getId(),
                 'name' => $mailbox->getName(),
                 'isEnabled' => $mailbox->getIsEnabled(),
-                'isDeleted' => $mailbox->getIsDeleted(),
+                'isDeleted' => $mailbox->getIsDeleted() ? $mailbox->getIsDeleted() : false,
             ];
         }, $this->mailboxService->parseMailboxConfigurations()->getMailboxes());
 

--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -86,7 +86,7 @@ class MailboxService
             ($mailbox = new Mailbox($id))
                 ->setName($params['name'])
                 ->setIsEnabled($params['enabled'])
-                ->setIsDeleted($params['deleted'])
+                ->setIsDeleted(empty($params['deleted']) ? false : $params['deleted'])
                 ->setImapConfiguration($imapConfiguration);
             
             if (!empty($swiftmailerConfiguration)) {


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
This will fetch the previous mailboxes listing without any error or deleted option 

### 2. What does this change do, exactly?
This will check whether the delete option is there or not if not it will take it as false.

### 3. Please link to the relevant issues (if any).
