### PR TITLE
Make a controller to convert email into ticket manually

### DIFF
--- a/Controller/MailboxChannelXHR.php
+++ b/Controller/MailboxChannelXHR.php
@@ -9,16 +9,31 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Webkul\UVDesk\MailboxBundle\Utils\MailboxConfiguration;
 use Webkul\UVDesk\MailboxBundle\Services\MailboxService;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class MailboxChannelXHR extends AbstractController
 {
     private $mailboxService;
     private $translator;
+    private $kernel;
 
-    public function __construct(MailboxService $mailboxService, TranslatorInterface $translator)
+    public function __construct(KernelInterface $kernel, MailboxService $mailboxService, TranslatorInterface $translator)
     {
         $this->mailboxService = $mailboxService;
         $this->translator = $translator;
+        $this->kernel = $kernel;
+    }
+
+    public function processRawContentMail(Request $request)
+    {
+        $rawEmail = file_get_contents($this->kernel->getProjectDir(). "/rawEmailContent.txt");
+
+        if ($rawEmail != false &&  !empty($rawEmail)) {
+           $this->mailboxService->processMail($rawEmail);
+        }else{
+            dump("Empty Text file not allow or check your file once");
+        } 
+        exit(0);
     }
 
     public function processMailXHR(Request $request)

--- a/Controller/MailboxChannelXHR.php
+++ b/Controller/MailboxChannelXHR.php
@@ -31,7 +31,7 @@ class MailboxChannelXHR extends AbstractController
         if ($rawEmail != false &&  !empty($rawEmail)) {
            $this->mailboxService->processMail($rawEmail);
         }else{
-            dump("Empty Text file not allow or check your file once");
+            dump("Empty Text file not allow");
         } 
         exit(0);
     }

--- a/Resources/config/routes/private.yaml
+++ b/Resources/config/routes/private.yaml
@@ -19,3 +19,7 @@ helpdesk_member_mailbox_remove_configuration_xhr:
     path:     /settings/mailbox/remove/{id}
     controller: Webkul\UVDesk\MailboxBundle\Controller\MailboxChannelXHR::removeMailboxConfiguration
     defaults: { id: ''}
+
+helpdesk_member_mailbox_direct_convert_mail:
+    path:     /processRawEmail
+    controller: Webkul\UVDesk\MailboxBundle\Controller\MailboxChannelXHR::processRawContentMail


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

1. Why is this change necessary?
This will help User & developer when the refresh commands are not able to convert mail into iticket.

2. What does this change do, exactly?
This will help User & developer to check directly put the raw content of the email inside this "rawEmailContent.txt" file. Then hit "/**processRawEmail**" &  put **dump** in process mail to check step by step.

3. Please link to the relevant issues (if any).
