### PR TITLE
Email replies cause new ticket thread => fixed

### DIFF
--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -226,7 +226,10 @@ class MailboxService
                     break;
                 case 'inReplyTo':
                     // Search Criteria 2: Find ticket based on in-reply-to reference id
-                    $ticket = $ticketRepository->findOneByReferenceIds($criteriaValue);
+
+                    $repository = $this->entityManager->getRepository('UVDeskCoreFrameworkBundle:Thread');
+                    $ticket = $repository->findThreadByRefrenceId($criteriaValue);
+
 
                     if (!empty($ticket)) {
                         return $ticket;


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If the reference Id is missing no reply is added to the ticket & create a new ticket.

### 2. What does this change do, exactly?
Added message-id to reference id if reference ids missing in the header then compare to in-reply-to.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/478
