### PR TITLE
replyTo ckey check

### DIFF
--- a/Services/MailboxService.php
+++ b/Services/MailboxService.php
@@ -325,7 +325,7 @@ class MailboxService
         }
 
         // Process Mail - References
-        $addresses['to'][0] = strtolower($mailData['replyTo']) ?? strtolower($addresses['to'][0]);
+        $addresses['to'][0] = isset($mailData['replyTo']) ? strtolower($mailData['replyTo']) : strtolower($addresses['to'][0]);
         $mailData['replyTo'] = $addresses['to'];
         $mailData['messageId'] = $parser->getHeader('message-id') ?: null;
         $mailData['inReplyTo'] = htmlspecialchars_decode($parser->getHeader('in-reply-to'));


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If no mailbox exists in-reply-to key then it will create an error

### 2. What does this change do, exactly?
check whether the key exists or not.

### 3. Please link to the relevant issues (if any).
