### PR TITLE
Tickets are created from aliases or copied msgs.

### DIFF
--- a/Console/RefreshMailboxCommand.php
+++ b/Console/RefreshMailboxCommand.php
@@ -39,7 +39,7 @@ class RefreshMailboxCommand extends Command
         $mailboxEmailCollection = array_map(function ($email) {
             return filter_var($email, FILTER_SANITIZE_EMAIL);
         }, $input->getArgument('emails'));
-       
+
         // Stop execution if no valid emails have been specified
         if (empty($mailboxEmailCollection)) {
             if (false === $input->getOption('no-interaction')) {
@@ -61,13 +61,13 @@ class RefreshMailboxCommand extends Command
                     if (false === $input->getOption('no-interaction')) {
                         $output->writeln("\n <comment>Mailbox for email </comment><info>$mailboxEmail</info><comment> is not enabled.</comment>\n");
                     }
-    
+
                     continue;
                 } else if (empty($mailbox['imap_server'])) {
                     if (false === $input->getOption('no-interaction')) {
                         $output->writeln("\n <comment>No imap configurations defined for email </comment><info>$mailboxEmail</info><comment>.</comment>\n");
                     }
-    
+
                     continue;
                 }
             } catch (\Exception $e) {
@@ -105,11 +105,11 @@ class RefreshMailboxCommand extends Command
                 $output->writeln("\n <comment>5. Total fetched email -> </comment><info>$emailCount</info><comment></comment>");
                 $output->writeln("\n <comment>6. Starting to convert Emails into Tickets -> </comment>\n=============================================\n=============================================\n");
                 $counter = 1;
-                
+
                 foreach ($emailCollection as $id => $messageNumber) {
                     $output->writeln("\n <comment> Converting email </comment><info>$counter</info><comment> out of </comment><info>$emailCount</info><comment>.</comment>");
                     $message = imap_fetchbody($imap, $messageNumber, "");
-                    $this->pushMessage($message, $useSecureConnection, $output);
+                    $this->pushMessage($message, $useSecureConnection, $output, $mailbox);
                     if (true == $mailbox['deleted']) {
                         imap_delete($imap, $messageNumber);
                     }
@@ -127,20 +127,23 @@ class RefreshMailboxCommand extends Command
         return;
     }
 
-    public function pushMessage($message, bool $secure = false, $output)
+    public function pushMessage($message, bool $secure = false, $output, $mailbox)
     {
         $router = $this->container->get('router');
         $router->getContext()->setHost($this->container->getParameter('uvdesk.site_url'));
         $router->getContext()->setScheme(true === $secure ? 'https' : 'http');
 
         $curlHandler = curl_init();
-        $requestUrl = $router->generate('helpdesk_member_mailbox_notification', [], UrlGeneratorInterface::ABSOLUTE_URL);   
-        
+        $requestUrl = $router->generate('helpdesk_member_mailbox_notification', [], UrlGeneratorInterface::ABSOLUTE_URL);
+
         curl_setopt($curlHandler, CURLOPT_HEADER, 0);
         curl_setopt($curlHandler, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curlHandler, CURLOPT_POST, 1);
         curl_setopt($curlHandler, CURLOPT_URL, $requestUrl);
-        curl_setopt($curlHandler, CURLOPT_POSTFIELDS, http_build_query(['email' => $message]));
+        curl_setopt($curlHandler, CURLOPT_POSTFIELDS, http_build_query([
+            'email' => $message,
+            'mailbox' => $mailbox['email'],
+        ]));
 
         $curlResponse = curl_exec($curlHandler);
         if ($curlResponse != 200 ) {

--- a/Controller/MailboxChannelXHR.php
+++ b/Controller/MailboxChannelXHR.php
@@ -32,7 +32,7 @@ class MailboxChannelXHR extends AbstractController
            $this->mailboxService->processMail($rawEmail);
         }else{
             dump("Empty Text file not allow");
-        } 
+        }
         exit(0);
     }
 
@@ -43,12 +43,14 @@ class MailboxChannelXHR extends AbstractController
         $response->send();
 
         if ("POST" == $request->getMethod() && null != $request->get('email')) {
-            $this->mailboxService->processMail($request->get('email'));
+            $rawEmail = $request->get('email');
+            $mailboxEmail = $request->get('mailbox');
+            $this->mailboxService->processMail($rawEmail, $mailboxEmail);
         }
-        
+
         exit(0);
     }
-    
+
     public function loadMailboxesXHR(Request $request)
     {
         $collection = array_map(function ($mailbox) {


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Uvdesk does not create tickets from aliases. @see #85 (expecially [this comment](https://github.com/uvdesk/mailbox-component/issues/85#issuecomment-1099542347)) for details.
Also, in addition to the added features mentioned in the comment above, with this patch, tickets can be created also from messages copied, with Thunderbird (tested) for exeample, from a non Uvdesk email Inbox to an Uvdesk's cofigured mailbox Inbox.

### 2. What does this change do, exactly?
It changes `uvdesk:refresh-mailbox` command to send mailbox email as parameter in request and `MailboxService::processMail` use this parameter to set correct mailbox to created ticket.

### 3. Please link to the relevant issues (if any).
See #85 (expecially [this comment](https://github.com/uvdesk/mailbox-component/issues/85#issuecomment-1099542347))

This fixes #85 and uvdesk/community-skeleton#555.

It also fixes ticket submissions from PHP forms like the ones mentioned in uvdesk/community-skeleton#531 (after this patch, this issue is fixed also). I've tested with both, message to an alias and message to Uvdesk mailbox - they both work and tickets are created. I've attached the test messages exported from Thunderbird - ofcorse, domain was ofuscated 😉.

[msg_from_site_form_to_alias.txt](https://github.com/uvdesk/mailbox-component/files/8495668/msg_from_site_form_to_alias.txt)
[msg_from_site_form_to_mailbox.txt](https://github.com/uvdesk/mailbox-component/files/8495669/msg_from_site_form_to_mailbox.txt)